### PR TITLE
Added option selectionMode

### DIFF
--- a/lib/ce/src/hot-column.component.ts
+++ b/lib/ce/src/hot-column.component.ts
@@ -101,6 +101,7 @@ export class HotColumnComponent implements OnInit, OnChanges, OnDestroy {
   @Input() rowHeaderWidth: number | number[];
   @Input() rowHeights: number | number[] | string | ((row: number) => number);
   @Input() search: boolean;
+  @Input() selectionMode: string;
   @Input() selectOptions: string[] | number[];
   @Input() skipColumnOnPaste: boolean;
   @Input() sortByRelevance: boolean;

--- a/lib/ce/src/hot-settings-resolver.service.ts
+++ b/lib/ce/src/hot-settings-resolver.service.ts
@@ -13,7 +13,7 @@ const AVAILABLE_OPTIONS: string[] = ['allowEmpty', 'allowHtml', 'allowInsertColu
 'noWordWrapClassName', 'numericFormat', 'observeChanges', 'observeDOMVisibility', 'outsideClickDeselects',
 'persistentState', 'placeholder', 'placeholderCellClassName', 'preventOverflow', 'readOnly',
 'readOnlyCellClassName', 'renderAllRows', 'renderer', 'rowHeaders', 'rowHeaderWidth', 'rowHeights',
-'search', 'selectOptions', 'skipColumnOnPaste', 'sortByRelevance', 'sortFunction', 'sortIndicator',
+'search', 'selectionMode', 'selectOptions', 'skipColumnOnPaste', 'sortByRelevance', 'sortFunction', 'sortIndicator',
 'source', 'startCols', 'startRows', 'stretchH', 'strict', 'tableClassName', 'tabMoves', 'title',
 'trimDropdown', 'trimWhitespace', 'type', 'uncheckedTemplate', 'undo', 'validator',
 'viewportColumnRenderingOffset', 'viewportRowRenderingOffset', 'visibleRows', 'width', 'wordWrap'];

--- a/lib/ce/src/hot-table.component.ts
+++ b/lib/ce/src/hot-table.component.ts
@@ -118,6 +118,7 @@ export class HotTableComponent implements AfterContentInit, OnChanges, OnDestroy
   @Input() rowHeaderWidth: number | number[];
   @Input() rowHeights: number | number[] | string | ((row: number) => number);
   @Input() search: boolean;
+  @Input() selectionMode: string;
   @Input() selectOptions: string[] | number[];
   @Input() skipColumnOnPaste: boolean;
   @Input() sortByRelevance: boolean;

--- a/lib/pro/src/hot-column.component.ts
+++ b/lib/pro/src/hot-column.component.ts
@@ -102,6 +102,7 @@ export class HotColumnComponent implements OnInit, OnChanges, OnDestroy {
   @Input() rowHeaderWidth: number | number[];
   @Input() rowHeights: number | number[] | string | ((row: number) => number);
   @Input() search: boolean;
+  @Input() selectionMode: string;
   @Input() selectOptions: string[] | number[];
   @Input() skipColumnOnPaste: boolean;
   @Input() sortByRelevance: boolean;

--- a/lib/pro/src/hot-settings-resolver.service.ts
+++ b/lib/pro/src/hot-settings-resolver.service.ts
@@ -13,7 +13,7 @@ const AVAILABLE_OPTIONS: string[] = ['allowEmpty', 'allowHtml', 'allowInsertColu
 'noWordWrapClassName', 'numericFormat', 'observeChanges', 'observeDOMVisibility', 'outsideClickDeselects',
 'persistentState', 'placeholder', 'placeholderCellClassName', 'preventOverflow', 'readOnly',
 'readOnlyCellClassName', 'renderAllRows', 'renderer', 'rowHeaders', 'rowHeaderWidth', 'rowHeights',
-'search', 'selectOptions', 'skipColumnOnPaste', 'sortByRelevance', 'sortFunction', 'sortIndicator',
+'search', 'selectionMode', 'selectOptions', 'skipColumnOnPaste', 'sortByRelevance', 'sortFunction', 'sortIndicator',
 'source', 'startCols', 'startRows', 'stretchH', 'strict', 'tableClassName', 'tabMoves', 'title',
 'trimDropdown', 'trimWhitespace', 'type', 'uncheckedTemplate', 'undo', 'validator',
 'viewportColumnRenderingOffset', 'viewportRowRenderingOffset', 'visibleRows', 'width', 'wordWrap'];

--- a/lib/pro/src/hot-table.component.ts
+++ b/lib/pro/src/hot-table.component.ts
@@ -117,6 +117,7 @@ export class HotTableComponent implements AfterContentInit, OnChanges, OnDestroy
   @Input() rowHeaderWidth: number | number[];
   @Input() rowHeights: number | number[] | string | ((row: number) => number);
   @Input() search: boolean;
+  @Input() selectionMode: string;
   @Input() selectOptions: string[] | number[];
   @Input() skipColumnOnPaste: boolean;
   @Input() sortByRelevance: boolean;


### PR DESCRIPTION
### Context
Adds the option selectionMode as added in handsontable 0.36.0

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project,
- [ ] My change requires a change to the documentation.