### PR TITLE
UpdateSettings should be run outside of the Angular zone

### DIFF
--- a/lib/ce/src/hot-table.component.ts
+++ b/lib/ce/src/hot-table.component.ts
@@ -339,7 +339,9 @@ export class HotTableComponent implements AfterContentInit, OnChanges, OnDestroy
       return;
     }
 
-    this.hotInstance.updateSettings(newSettings, false);
+    this._ngZone.runOutsideAngular(() => {
+      this.hotInstance.updateSettings(newSettings, false);
+    });
   }
 
   onAfterColumnsChange(): void {

--- a/lib/pro/src/hot-table.component.ts
+++ b/lib/pro/src/hot-table.component.ts
@@ -373,7 +373,9 @@ export class HotTableComponent implements AfterContentInit, OnChanges, OnDestroy
       return;
     }
 
-    this.hotInstance.updateSettings(newSettings, false);
+    this._ngZone.runOutsideAngular(() => {
+      this.hotInstance.updateSettings(newSettings, false);
+    });
   }
 
   onAfterColumnsChange(): void {


### PR DESCRIPTION
### Context
If `updateSettings()` was called once in component's `Zone`, then all of the mounted listeners from `Handsontable` calls `ngDoChange()`.

### How has this been tested?
Use similar configuration as in issue's demo: http://jsfiddle.net/salcio/pj28uc4y/

### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

### Related issue(s):
1. #116 