### PR TITLE
Should be possible to get custom option over to settings object.

### DIFF
--- a/lib/ce/src/hot-settings-resolver.service.ts
+++ b/lib/ce/src/hot-settings-resolver.service.ts
@@ -7,14 +7,16 @@ const AVAILABLE_HOOKS: string[] = Handsontable.hooks.getRegistered();
 
 @Injectable()
 export class HotSettingsResolver {
-  mergeSettings(component): Handsontable.GridSettings {
-    const mergedSettings: Handsontable.GridSettings = {};
+  mergeSettings(component): Handsontable.GridSettings | object {
+    const isSettingsObject = typeof component['settings'] === 'object';
+    const mergedSettings: Handsontable.GridSettings = isSettingsObject ? component['settings'] : {};
     const options = AVAILABLE_HOOKS.concat(AVAILABLE_OPTIONS);
 
     options.forEach(key => {
+      const isHook = AVAILABLE_HOOKS.indexOf(key) > -1;
       let option;
 
-      if (typeof component['settings'] === 'object') {
+      if (isSettingsObject && isHook) {
         option = component['settings'][key];
       }
 
@@ -25,7 +27,7 @@ export class HotSettingsResolver {
       if (option === void 0) {
         return;
 
-      } else if (typeof option === 'function' && AVAILABLE_HOOKS.indexOf(key) > -1) {
+      } else if (typeof option === 'function' && isHook) {
         mergedSettings[key] = function(...args) {
           return component._ngZone.run(() => {
             return option(this, ...args);

--- a/lib/pro/src/hot-settings-resolver.service.ts
+++ b/lib/pro/src/hot-settings-resolver.service.ts
@@ -7,14 +7,16 @@ const AVAILABLE_HOOKS: string[] = Handsontable.hooks.getRegistered();
 
 @Injectable()
 export class HotSettingsResolver {
-  mergeSettings(component): Handsontable.GridSettings {
-    const mergedSettings: Handsontable.GridSettings = {};
+  mergeSettings(component): Handsontable.GridSettings | object {
+    const isSettingsObject = typeof component['settings'] === 'object';
+    const mergedSettings: Handsontable.GridSettings = isSettingsObject ? component['settings'] : {};
     const options = AVAILABLE_HOOKS.concat(AVAILABLE_OPTIONS);
 
     options.forEach((key) => {
+      const isHook = AVAILABLE_HOOKS.indexOf(key) > -1;
       let option;
 
-      if (typeof component['settings'] === 'object') {
+      if (isSettingsObject && isHook) {
         option = component['settings'][key];
       }
 
@@ -25,7 +27,7 @@ export class HotSettingsResolver {
       if (option === void 0) {
         return;
 
-      } else if (typeof option === 'function' && AVAILABLE_HOOKS.indexOf(key) > -1) {
+      } else if (typeof option === 'function' && isHook) {
         mergedSettings[key] = function(...args) {
           return component._ngZone.run(() => {
             return option(this, ...args);

--- a/src/app/hot-table-ce.component.spec.ts
+++ b/src/app/hot-table-ce.component.spec.ts
@@ -96,6 +96,25 @@ describe('HotTableComponent', () => {
       });
     });
 
+    it(`should be possible to get custom option over to 'settings' defined as bindings`, () => {
+      TestBed.overrideComponent(TestComponent, {
+        set: {
+          template: `<hot-table [hotId]="id" [settings]="prop.settings"></hot-table>`
+        }
+      });
+      TestBed.compileComponents().then(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        const app = fixture.componentInstance;
+
+        app.prop['settings'] = {
+          customOption: 'test'
+        };
+
+        fixture.detectChanges();
+        expect(app.getHotInstance(app.id).getSettings()['customOption']).toBe('test');
+      });
+    });
+
     it(`should set activeHeaderClassName defined as bindings`, () => {
       TestBed.overrideComponent(TestComponent, {
         set: {

--- a/src/app/hot-table-pro.component.spec.ts
+++ b/src/app/hot-table-pro.component.spec.ts
@@ -96,6 +96,25 @@ describe('HotTableComponent', () => {
       });
     });
 
+    it(`should be possible to get custom option over to 'settings' defined as bindings`, () => {
+      TestBed.overrideComponent(TestComponent, {
+        set: {
+          template: `<hot-table [hotId]="id" [settings]="prop.settings"></hot-table>`
+        }
+      });
+      TestBed.compileComponents().then(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        const app = fixture.componentInstance;
+
+        app.prop['settings'] = {
+          customOption: 'test'
+        };
+
+        fixture.detectChanges();
+        expect(app.getHotInstance(app.id).getSettings()['customOption']).toBe('test');
+      });
+    });
+
     it(`should set activeHeaderClassName defined as bindings`, () => {
       TestBed.overrideComponent(TestComponent, {
         set: {


### PR DESCRIPTION
### Context
The previous implementation excludes custom options defined in `@Input settings`. Because of that, customization is impossible.

### How has this been tested?
1. Define settings object with custom property.
2. `hotInstance.getSettings()['yourProportyKey']` should be available.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature or improvement (a non-breaking change which adds functionality)

### Related issue(s):
1. #124