### PR TITLE
add @angular/core to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "release": "npm run test && npm publish dist/hot-table --access public"
   },
   "peerDependencies": {
+    "@angular/core": ">= 8",
     "handsontable": "^8.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "release": "npm run test && npm publish dist/hot-table --access public"
   },
   "peerDependencies": {
-    "@angular/core": ">= 8",
+    "@angular/core": ">= 7",
     "handsontable": "^8.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #215 

~I'm not sure if versions prior to 8 should be supported, if so, the range should be updated.~ (as per https://github.com/handsontable/angular-handsontable/pull/157 it seems that 7 and 8 both work, updated the range to `>= 7`)

See #215 for context.